### PR TITLE
Make CSS sanitiser recognize newer Google Fonts import snippet

### DIFF
--- a/render.js
+++ b/render.js
@@ -256,7 +256,7 @@ var $renderKey = (typeof(exports) !== 'undefined') ? exports : {};
 					css += "}\n";
 				} else {
 					var ok = (rule.name === "@font-face")
-					      || (rule.name === "@import" && !rule.content && rule.selector.match(/^url\(http:\/\/fonts.googleapis.com\/css\?family=[^\)]+\)$/));
+					      || (rule.name === "@import" && !rule.content && rule.selector.match(/^url\('?https?:\/\/fonts.googleapis.com\/css\?family=[^\)]+'?\)$/));
 					if(ok) {
 						css += rule.name;
 						if(rule.selector) css += ' ' + rule.selector;


### PR DESCRIPTION
Google Fonts now supplies an HTTPS rather than HTTP URL in its snippet, and adds quotes around the URL string. This change allows such snippets to survive the sanitation process.