### PR TITLE
Fix moving rotated keys

### DIFF
--- a/kb.js
+++ b/kb.js
@@ -1082,6 +1082,8 @@
 				$scope.selectedKeys.forEach(function(selectedKey) {
 					selectedKey.x = Math.round10(Math.max(0,selectedKey.x + x),-2);
 					selectedKey.y = Math.round10(Math.max(0,selectedKey.y + y),-2);
+					selectedKey.rotation_x =Math.round10(Math.max(0,selectedKey.rotation_x + x),-2);
+					selectedKey.rotation_y = Math.round10(Math.max(0,selectedKey.rotation_y + y),-2);
 					renderKey(selectedKey);
 				});
 				$scope.multi = angular.copy($scope.selectedKeys.last());


### PR DESCRIPTION
Moving ErgoDox keys 5 times before this commit:
![image](https://user-images.githubusercontent.com/18114381/65818364-91d18d00-e219-11e9-968c-c5505a16a1ee.png)

Moving ErgoDox keys 5 times after this commit:
![image](https://user-images.githubusercontent.com/18114381/65818380-bf1e3b00-e219-11e9-9be6-93086272200e.png)

(don't look at keys style, it's my local modifications)