### PR TITLE
add text labels to SVG, wide tags

### DIFF
--- a/kb.html
+++ b/kb.html
@@ -1345,8 +1345,8 @@ DOT.js Templates
       {{?}}
       {{? i==8 }}
       </svg>
-      <svg x="{{=parms.textcapx}}" y="{{=parms.outercapy+sizes.strokeWidth*2}}" width="{{=parms.textcapwidth}}" height="{{=parms.outercapheight-sizes.strokeWidth*2}}" class='keylabels'>
-    {{?}} {{ /* i==8 */ }}
+      <svg x="{{=parms.textcapx}}" y="{{=parms.outercapy+sizes.strokeWidth*2}}" width="{{=parms.textcapwidth}}" height="{{=parms.outercapheight-sizes.strokeWidth}}" class='keylabels'>
+      {{?}} {{ /* i==8 */ }}
     {{~}}
     </svg>
     <svg x='{{=parms.textcapx}}' y='{{=parms.textcapy}}' width='{{=parms.textcapwidth}}' height='{{=parms.textcapheight}}' class='keylabels'>

--- a/kb.html
+++ b/kb.html
@@ -1277,7 +1277,18 @@ DOT.js Templates
 </script>
 
 <!-- Keycap Template for SVG-->
-<script type="text/ng-template" id="keycap_svg">
+<script type="text/ng-template" id="keycap_svg">{{
+  let labelTranslations = [
+    [0, 0]  , [0.5, 0]  , [1, 0],
+    [0, 0.5], [0.5, 0.5], [1, 0.5],
+    [0, 1]  , [0.5, 1]  , [1, 1],
+    [0, 1]  , [0.5, 1]  , [1, 1],
+  ];
+  var labelTranslate = (n, width, height) => {
+    let xlat = labelTranslations[n];
+    return "translate(" + (xlat[0] * width) + " " + (xlat[1] * height) + ")";
+  };
+}}
   <g class='{{=key.ghost ? "ghosted" : ""}} {{=key.decal ? "decal" : ""}} keycap' {{? key.rotation_angle }} transform="rotate({{=key.rotation_angle}} {{=parms.origin_x}} {{=parms.origin_y}})" {{?}}>
   {{? !key.decal }}
     {{ /* Outer Border */ }}
@@ -1330,7 +1341,8 @@ DOT.js Templates
     {{?}} {{ /*ghost*/ }}
   {{?}} {{ /*decal*/ }}
   {{? !key.ghost }}
-    <svg x='{{=parms.textcapx}}' y='{{=parms.textcapy}}' width='{{=parms.textcapwidth}}' height='{{=parms.textcapheight}}' class='keylabels'>
+    {{ var viewSize = [parms.textcapwidth, parms.textcapheight]; }}
+    <svg viewBox="0 0 {{=viewSize[0]}} {{=viewSize[1]}}" x='{{=parms.textcapx}}' y='{{=parms.textcapy}}' width='{{=viewSize[0]}}' height='{{=viewSize[1]}}' class='keylabels'>
     {{~key.labels :label:i}}
       {{? label && label != "" }}
         {{ var sanitizedLabel = ""; try { sanitizedLabel = $sanitize(label.replace(/<([^a-zA-Z\/]|$)/,"&lt;$1")); } catch(e) {console.log(e);} }}
@@ -1338,19 +1350,16 @@ DOT.js Templates
           {{ var textSize = key.textSize[i] || key.default.textSize; }}
           {{ var textColor = key.textColor[i] || key.default.textColor; }}
           {{ if(i<9) textColor = lightenColor($color.hex(textColor), 1.2).hex(); }}
-          <text class='keylabel keylabel{{=i}} textsize{{=textSize}}' fill='{{=textColor}}'> {{=sanitizedLabel}} </text>
+          <text transform='{{=labelTranslate(i, ...viewSize)}}' class='keylabel keylabel{{=i}} textsize{{=textSize}}' fill='{{=textColor}}'> {{=sanitizedLabel}} </text>
         {{??}}
           <text>(err)</text>
         {{?}}
       {{?}}
       {{? i==8 }}
+      {{ viewSize[1] = parms.outercapheight - sizes.strokeWidth; }}
       </svg>
-      <svg x="{{=parms.textcapx}}" y="{{=parms.outercapy+sizes.strokeWidth*2}}" width="{{=parms.textcapwidth}}" height="{{=parms.outercapheight-sizes.strokeWidth}}" class='keylabels'>
+      <svg viewBox="0 0 {{=viewSize[0]}} {{=viewSize[1]}}" x="{{=parms.textcapx}}" y="{{=parms.outercapy+sizes.strokeWidth*2}}" width="{{=viewSize[0]}}" height="{{=viewSize[1]}}" class='keylabels'>
       {{?}} {{ /* i==8 */ }}
-    {{~}}
-    </svg>
-    <svg x='{{=parms.textcapx}}' y='{{=parms.textcapy}}' width='{{=parms.textcapwidth}}' height='{{=parms.textcapheight}}' class='keylabels'>
-    {{~key.labels :label:i}}
     {{~}}
     </svg>
   {{?}}
@@ -1363,27 +1372,16 @@ DOT.js Templates
   }} viewBox='0 0 {{=Math.ceil(parms.width+parms.margin*2+parms.padding*2)}} {{=Math.ceil(parms.height+parms.margin*2+parms.padding*2)}}' {{
   }} xmlns='http://www.w3.org/2000/svg' xmlns:xlink="http://www.w3.org/1999/xlink">
   <style type='text/css'>
+    .keycap { font-family: "Helvetica", "Arial", sans-serif; }
     .keycap .border { stroke: black; stroke-width: {{=parms.strokeWidth*2}}; }
     .keycap .inner.border { stroke: rgba(0,0,0,.1); }
-    .keylabel0, .keylabel1, .keylabel2 { dominant-baseline: hanging; }
+    .keylabel0, .keylabel1, .keylabel2 { dominant-baseline: text-before-edge; }
     .keylabel3, .keylabel4, .keylabel5 { dominant-baseline: central; }
-    .keylabel6, .keylabel7, .keylabel8 { dominant-baseline: ideographic; }
+    .keylabel6, .keylabel7, .keylabel8 { dominant-baseline: text-after-edge; }
     .keylabel9, .keylabel10, .keylabel11 { dominant-baseline: ideographic; font-size: 10px !important; max-height: 1em !important; white-space: nowrap; overflow: hidden; }
     .keylabel0, .keylabel3, .keylabel6, .keylabel9  { text-anchor: start; }
     .keylabel1, .keylabel4, .keylabel7, .keylabel10 { text-anchor: middle; }
     .keylabel2, .keylabel5, .keylabel8, .keylabel11 { text-anchor: end; }
-    .keylabel0  { transform: translateX(0%)   translateY(0%); }
-    .keylabel1  { transform: translateX(50%)  translateY(0%); }
-    .keylabel2  { transform: translateX(100%) translateY(0%); }
-    .keylabel3  { transform: translateX(0%)   translateY(50%); }
-    .keylabel4  { transform: translateX(50%)  translateY(50%); }
-    .keylabel5  { transform: translateX(100%) translateY(50%); }
-    .keylabel6  { transform: translateX(0%)   translateY(100%); }
-    .keylabel7  { transform: translateX(50%)  translateY(100%); }
-    .keylabel8  { transform: translateX(100%) translateY(100%); }
-    .keylabel9  { transform: translateX(0%)   translateY(100%); }
-    .keylabel10 { transform: translateX(50%)  translateY(100%); }
-    .keylabel11 { transform: translateX(100%) translateY(100%); }
     .keylabel.textsize1 { font-size: 8px ; line-height: 1em; }
     .keylabel.textsize2 { font-size: 10px; line-height: 1em; }
     .keylabel.textsize3 { font-size: 12px; line-height: 1em; }

--- a/kb.html
+++ b/kb.html
@@ -1278,49 +1278,29 @@ DOT.js Templates
 
 <!-- Keycap Template for SVG-->
 <script type="text/ng-template" id="keycap_svg">
-  <g class='{{=key.ghost ? "ghosted" : ""}} {{=key.decal ? "decal" : ""}} keycap'
-  {{? key.rotation_angle }}
-     transform="rotate({{=key.rotation_angle}} {{=parms.origin_x}} {{=parms.origin_y}})"
-  {{?}}>
-
+  <g class='{{=key.ghost ? "ghosted" : ""}} {{=key.decal ? "decal" : ""}} keycap' {{? key.rotation_angle }} transform="rotate({{=key.rotation_angle}} {{=parms.origin_x}} {{=parms.origin_y}})" {{?}}>
   {{? !key.decal }}
-    <!-- Outer Border -->
-    <rect x="{{=parms.outercapx+sizes.strokeWidth}}" y="{{=parms.outercapy+sizes.strokeWidth}}"
-          width="{{=parms.outercapwidth-sizes.strokeWidth*2}}" height="{{=parms.outercapheight-sizes.strokeWidth*2}}"
-          rx="{{=sizes.roundOuter}}" fill="{{=parms.darkColor}}" class="outer border"/>
+    {{ /* Outer Border */ }}
+    <rect x="{{=parms.outercapx+sizes.strokeWidth}}" y="{{=parms.outercapy+sizes.strokeWidth}}" width="{{=parms.outercapwidth-sizes.strokeWidth*2}}" height="{{=parms.outercapheight-sizes.strokeWidth*2}}" rx="{{=sizes.roundOuter}}" fill="{{=parms.darkColor}}" class="outer border"/>
     {{? parms.jShaped }}
-      <rect x="{{=parms.outercapx2+sizes.strokeWidth}}" y="{{=parms.outercapy2+sizes.strokeWidth}}"
-            width="{{=parms.outercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.outercapheight2-sizes.strokeWidth*2}}"
-            rx="{{=sizes.roundOuter}}" fill="{{=parms.darkColor}}" class="outer border"/>
+      <rect x="{{=parms.outercapx2+sizes.strokeWidth}}" y="{{=parms.outercapy2+sizes.strokeWidth}}" width="{{=parms.outercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.outercapheight2-sizes.strokeWidth*2}}" rx="{{=sizes.roundOuter}}" fill="{{=parms.darkColor}}" class="outer border"/>
     {{?}}
-    <!-- Outer Fill -->
-    <rect x="{{=parms.outercapx+sizes.strokeWidth}}" y="{{=parms.outercapy+sizes.strokeWidth}}"
-          width="{{=parms.outercapwidth-sizes.strokeWidth*2}}" height="{{=parms.outercapheight-sizes.strokeWidth*2}}"
-          rx="{{=sizes.roundOuter}}" fill="{{=parms.darkColor}}"/>
+    {{ /* Outer Fill */ }}
+    <rect x="{{=parms.outercapx+sizes.strokeWidth}}" y="{{=parms.outercapy+sizes.strokeWidth}}" width="{{=parms.outercapwidth-sizes.strokeWidth*2}}" height="{{=parms.outercapheight-sizes.strokeWidth*2}}" rx="{{=sizes.roundOuter}}" fill="{{=parms.darkColor}}"/>
     {{? parms.jShaped }}
-      <rect x="{{=parms.outercapx2+sizes.strokeWidth}}" y="{{=parms.outercapy2+sizes.strokeWidth}}"
-            width="{{=parms.outercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.outercapheight2-sizes.strokeWidth*2}}"
-            rx="{{=sizes.roundOuter}}" fill="{{=parms.darkColor}}"/>
+      <rect x="{{=parms.outercapx2+sizes.strokeWidth}}" y="{{=parms.outercapy2+sizes.strokeWidth}}" width="{{=parms.outercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.outercapheight2-sizes.strokeWidth*2}}" rx="{{=sizes.roundOuter}}" fill="{{=parms.darkColor}}"/>
     {{?}}
 
     {{? !key.ghost }}
-      <!-- Inner Border -->
-      <rect x="{{=parms.innercapx+sizes.strokeWidth}}" y="{{=parms.innercapy+sizes.strokeWidth}}"
-            width="{{=parms.innercapwidth-sizes.strokeWidth*2}}" height="{{=parms.innercapheight-sizes.strokeWidth*2}}"
-            rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}" class="inner border"/>
+      {{ /* Inner Border */ }}
+      <rect x="{{=parms.innercapx+sizes.strokeWidth}}" y="{{=parms.innercapy+sizes.strokeWidth}}" width="{{=parms.innercapwidth-sizes.strokeWidth*2}}" height="{{=parms.innercapheight-sizes.strokeWidth*2}}" rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}" class="inner border"/>
       {{? parms.jShaped && !key.stepped }}
-        <rect x="{{=parms.innercapx2+sizes.strokeWidth}}" y="{{=parms.innercapy2+sizes.strokeWidth}}"
-              width="{{=parms.innercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.innercapheight2-sizes.strokeWidth*2}}"
-              rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}" class="inner border"/>
+        <rect x="{{=parms.innercapx2+sizes.strokeWidth}}" y="{{=parms.innercapy2+sizes.strokeWidth}}" width="{{=parms.innercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.innercapheight2-sizes.strokeWidth*2}}" rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}" class="inner border"/>
       {{?}}
-      <!-- Inner Fill -->
-      <rect x="{{=parms.innercapx+sizes.strokeWidth}}" y="{{=parms.innercapy+sizes.strokeWidth}}"
-            width="{{=parms.innercapwidth-sizes.strokeWidth*2}}" height="{{=parms.innercapheight-sizes.strokeWidth*2}}"
-            rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}"/>
+      {{ /* Inner Fill */ }}
+      <rect x="{{=parms.innercapx+sizes.strokeWidth}}" y="{{=parms.innercapy+sizes.strokeWidth}}" width="{{=parms.innercapwidth-sizes.strokeWidth*2}}" height="{{=parms.innercapheight-sizes.strokeWidth*2}}" rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}"/>
       {{? parms.jShaped && !key.stepped }}
-        <rect x="{{=parms.innercapx2+sizes.strokeWidth}}" y="{{=parms.innercapy2+sizes.strokeWidth}}"
-              width="{{=parms.innercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.innercapheight2-sizes.strokeWidth*2}}"
-              rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}"/>
+        <rect x="{{=parms.innercapx2+sizes.strokeWidth}}" y="{{=parms.innercapy2+sizes.strokeWidth}}" width="{{=parms.innercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.innercapheight2-sizes.strokeWidth*2}}" rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}"/>
       {{?}}
       {{? sizes.profile !== "" }}
         {{var theProfile = sizes.profile; if(/\b(SPACE)\b/.exec(key.profile)) theProfile = "SPACE";}}
@@ -1336,73 +1316,113 @@ DOT.js Templates
             };
           }}
           {{? sizes.profile==="SA" || sizes.profile==="DSA" }}
-            <radialGradient id="{{=theProfile}}" xlink:href="#{{=sizes.profile}}" gradientUnits="userSpaceOnUse"
-                            cx="{{=(rect.left+rect.right)/2}}" cy="{{=(rect.top+rect.bottom)/2}}"
-                            r="{{=Math.min(rect.right-rect.left, rect.bottom-rect.top)}}"/>
+            <radialGradient id="{{=theProfile}}" xlink:href="#{{=sizes.profile}}" gradientUnits="userSpaceOnUse" cx="{{=(rect.left+rect.right)/2}}" cy="{{=(rect.top+rect.bottom)/2}}" r="{{=Math.min(rect.right-rect.left, rect.bottom-rect.top)}}"/>
           {{??}}
-            <linearGradient id="{{=theProfile}}" xlink:href="#{{=sizes.profile}}" gradientUnits="userSpaceOnUse"
-                            x1="{{=rect.left}}" y1="{{=rect.top}}" x2="{{=rect.right}}" y2="{{=rect.top}}"/>
+            <linearGradient id="{{=theProfile}}" xlink:href="#{{=sizes.profile}}" gradientUnits="userSpaceOnUse" x1="{{=rect.left}}" y1="{{=rect.top}}" x2="{{=rect.right}}" y2="{{=rect.top}}"/>
           {{?}}
-          <rect x="{{=parms.innercapx2+sizes.strokeWidth}}" y="{{=parms.innercapy2+sizes.strokeWidth}}"
-                width="{{=parms.innercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.innercapheight2-sizes.strokeWidth*2}}"
-                rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}"/>
-          <rect x="{{=parms.innercapx2+sizes.strokeWidth}}" y="{{=parms.innercapy2+sizes.strokeWidth}}"
-                width="{{=parms.innercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.innercapheight2-sizes.strokeWidth*2}}"
-                rx="{{=sizes.roundOuter}}" fill="url(#{{=theProfile}})"/>
-          <rect x="{{=parms.innercapx+sizes.strokeWidth}}" y="{{=parms.innercapy+sizes.strokeWidth}}"
-                width="{{=parms.innercapwidth-sizes.strokeWidth*2}}" height="{{=parms.innercapheight-sizes.strokeWidth*2}}"
-                rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}"/>
+          <rect x="{{=parms.innercapx2+sizes.strokeWidth}}" y="{{=parms.innercapy2+sizes.strokeWidth}}" width="{{=parms.innercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.innercapheight2-sizes.strokeWidth*2}}" rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}"/>
+          <rect x="{{=parms.innercapx2+sizes.strokeWidth}}" y="{{=parms.innercapy2+sizes.strokeWidth}}" width="{{=parms.innercapwidth2-sizes.strokeWidth*2}}" height="{{=parms.innercapheight2-sizes.strokeWidth*2}}" rx="{{=sizes.roundOuter}}" fill="url(#{{=theProfile}})"/>
+          <rect x="{{=parms.innercapx+sizes.strokeWidth}}"  y="{{=parms.innercapy+sizes.strokeWidth}}"  width="{{=parms.innercapwidth-sizes.strokeWidth*2}}"  height="{{=parms.innercapheight-sizes.strokeWidth*2}}"  rx="{{=sizes.roundOuter}}" fill="{{=parms.lightColor}}"/>
         {{?}}
-        <rect x="{{=parms.innercapx+sizes.strokeWidth}}" y="{{=parms.innercapy+sizes.strokeWidth}}"
-              width="{{=parms.innercapwidth-sizes.strokeWidth*2}}" height="{{=parms.innercapheight-sizes.strokeWidth*2}}"
-              rx="{{=sizes.roundOuter}}" fill="url(#{{=theProfile}})"/>
+        <rect x="{{=parms.innercapx+sizes.strokeWidth}}" y="{{=parms.innercapy+sizes.strokeWidth}}" width="{{=parms.innercapwidth-sizes.strokeWidth*2}}" height="{{=parms.innercapheight-sizes.strokeWidth*2}}" rx="{{=sizes.roundOuter}}" fill="url(#{{=theProfile}})"/>
       {{?}}
 
     {{?}} {{ /*ghost*/ }}
   {{?}} {{ /*decal*/ }}
+  {{? !key.ghost }}
+    <svg x='{{=parms.textcapx}}' y='{{=parms.textcapy}}' width='{{=parms.textcapwidth}}' height='{{=parms.textcapheight}}' class='keylabels'>
+    {{~key.labels :label:i}}
+      {{? label && label != "" }}
+        {{ var sanitizedLabel = ""; try { sanitizedLabel = $sanitize(label.replace(/<([^a-zA-Z\/]|$)/,"&lt;$1")); } catch(e) {console.log(e);} }}
+        {{? sanitizedLabel !== "" }}
+          {{ var textSize = key.textSize[i] || key.default.textSize; }}
+          {{ var textColor = key.textColor[i] || key.default.textColor; }}
+          {{ if(i<9) textColor = lightenColor($color.hex(textColor), 1.2).hex(); }}
+          <text class='keylabel keylabel{{=i}} textsize{{=textSize}}' fill='{{=textColor}}'> {{=sanitizedLabel}} </text>
+        {{??}}
+          <text>(err)</text>
+        {{?}}
+      {{?}}
+      {{? i==8 }}
+      </svg>
+      <svg x="{{=parms.textcapx}}" y="{{=parms.outercapy+sizes.strokeWidth*2}}" width="{{=parms.textcapwidth}}" height="{{=parms.outercapheight-sizes.strokeWidth*2}}" class='keylabels'>
+    {{?}} {{ /* i==8 */ }}
+    {{~}}
+    </svg>
+    <svg x='{{=parms.textcapx}}' y='{{=parms.textcapy}}' width='{{=parms.textcapwidth}}' height='{{=parms.textcapheight}}' class='keylabels'>
+    {{~key.labels :label:i}}
+    {{~}}
+    </svg>
+  {{?}}
   </g>
 </script>
 
 <script type="text/ng-template" id="keyboard_svg">
-  <svg width='{{=parms.width+parms.margin*2+parms.padding*2}}{{=parms.units}}'
-       height='{{=parms.height+parms.margin*2+parms.padding*2}}{{=parms.units}}'
-       viewBox='0 0 {{=parms.width+parms.margin*2+parms.padding*2}} {{=parms.height+parms.margin*2+parms.padding*2}}'
-       xmlns='http://www.w3.org/2000/svg'
-       xmlns:xlink="http://www.w3.org/1999/xlink">
-
-    <style type='text/css'>
+<svg width='{{=Math.ceil(parms.width+parms.margin*2+parms.padding*2)}}{{=parms.units}}' {{
+  }} height='{{=Math.ceil(parms.height+parms.margin*2+parms.padding*2)}}{{=parms.units}}' {{
+  }} viewBox='0 0 {{=Math.ceil(parms.width+parms.margin*2+parms.padding*2)}} {{=Math.ceil(parms.height+parms.margin*2+parms.padding*2)}}' {{
+  }} xmlns='http://www.w3.org/2000/svg' xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style type='text/css'>
     .keycap .border { stroke: black; stroke-width: {{=parms.strokeWidth*2}}; }
     .keycap .inner.border { stroke: rgba(0,0,0,.1); }
-    </style>
-    <defs>
-      <linearGradient id="DCS">
-        <stop offset="0%" stop-color="black" stop-opacity="0"/>
-        <stop offset="40%" stop-color="black" stop-opacity="0.1"/>
-        <stop offset="60%" stop-color="black" stop-opacity="0.1"/>
-        <stop offset="100%" stop-color="black" stop-opacity="0"/>
-      </linearGradient>
-      <linearGradient id="SPACE" x1="0%" x2="0%" y1="0%" y2="100%">
-        <stop offset="0%" stop-color="black" stop-opacity="0.1"/>
-        <stop offset="20%" stop-color="black" stop-opacity="0.0"/>
-        <stop offset="40%" stop-color="black" stop-opacity="0.0"/>
-        <stop offset="100%" stop-color="black" stop-opacity="0.1"/>
-      </linearGradient>
-      <radialGradient id="DSA">
-        <stop offset="0%" stop-color="black" stop-opacity="0.1"/>
-        <stop offset="10%" stop-color="black" stop-opacity="0.1"/>
-        <stop offset="100%" stop-color="black" stop-opacity="0"/>
-      </radialGradient>
-      <radialGradient id="SA" xlink:href="#DSA" />
-    </defs>
+    .keylabel0, .keylabel1, .keylabel2 { dominant-baseline: hanging; }
+    .keylabel3, .keylabel4, .keylabel5 { dominant-baseline: central; }
+    .keylabel6, .keylabel7, .keylabel8 { dominant-baseline: ideographic; }
+    .keylabel9, .keylabel10, .keylabel11 { dominant-baseline: ideographic; font-size: 10px !important; max-height: 1em !important; white-space: nowrap; overflow: hidden; }
+    .keylabel0, .keylabel3, .keylabel6, .keylabel9  { text-anchor: start; }
+    .keylabel1, .keylabel4, .keylabel7, .keylabel10 { text-anchor: middle; }
+    .keylabel2, .keylabel5, .keylabel8, .keylabel11 { text-anchor: end; }
+    .keylabel0  { transform: translateX(0%)   translateY(0%); }
+    .keylabel1  { transform: translateX(50%)  translateY(0%); }
+    .keylabel2  { transform: translateX(100%) translateY(0%); }
+    .keylabel3  { transform: translateX(0%)   translateY(50%); }
+    .keylabel4  { transform: translateX(50%)  translateY(50%); }
+    .keylabel5  { transform: translateX(100%) translateY(50%); }
+    .keylabel6  { transform: translateX(0%)   translateY(100%); }
+    .keylabel7  { transform: translateX(50%)  translateY(100%); }
+    .keylabel8  { transform: translateX(100%) translateY(100%); }
+    .keylabel9  { transform: translateX(0%)   translateY(100%); }
+    .keylabel10 { transform: translateX(50%)  translateY(100%); }
+    .keylabel11 { transform: translateX(100%) translateY(100%); }
+    .keylabel.textsize1 { font-size: 8px ; line-height: 1em; }
+    .keylabel.textsize2 { font-size: 10px; line-height: 1em; }
+    .keylabel.textsize3 { font-size: 12px; line-height: 1em; }
+    .keylabel.textsize4 { font-size: 14px; line-height: 1em; }
+    .keylabel.textsize5 { font-size: 16px; line-height: 1em; }
+    .keylabel.textsize6 { font-size: 18px; line-height: 1em; }
+    .keylabel.textsize7 { font-size: 20px; line-height: 1em; }
+    .keylabel.textsize8 { font-size: 22px; line-height: 1em; }
+    .keylabel.textsize9 { font-size: 24px; line-height: 1em; }
+  </style>
+  <defs>
+    <linearGradient id="DCS">
+      <stop offset="0%" stop-color="black" stop-opacity="0"/>
+      <stop offset="40%" stop-color="black" stop-opacity="0.1"/>
+      <stop offset="60%" stop-color="black" stop-opacity="0.1"/>
+      <stop offset="100%" stop-color="black" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="SPACE" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="black" stop-opacity="0.1"/>
+      <stop offset="20%" stop-color="black" stop-opacity="0.0"/>
+      <stop offset="40%" stop-color="black" stop-opacity="0.0"/>
+      <stop offset="100%" stop-color="black" stop-opacity="0.1"/>
+    </linearGradient>
+    <radialGradient id="DSA">
+      <stop offset="0%" stop-color="black" stop-opacity="0.1"/>
+      <stop offset="10%" stop-color="black" stop-opacity="0.1"/>
+      <stop offset="100%" stop-color="black" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="SA" xlink:href="#DSA" />
+  </defs>
 
-    <g transform='translate({{=parms.margin}},{{=parms.margin}})'>
-      <rect width="{{=parms.width+parms.padding*2}}" height="{{=parms.height+parms.padding*2}}"
-            stroke="#ddd" stroke-width="1" fill="{{=parms.backcolor}}" rx="6"/>
-      <g transform='translate({{=parms.padding}},{{=parms.padding}})'>
-        {{=parms.keys}}
-      </g>
+  <g transform='translate({{=parms.margin}},{{=parms.margin}})'>
+    <rect width="{{=parms.width+parms.padding*2}}" height="{{=parms.height+parms.padding*2}}"
+          stroke="#ddd" stroke-width="1" fill="{{=parms.backcolor}}" rx="6"/>
+    <g transform='translate({{=parms.padding}},{{=parms.padding}})'>
+      {{=parms.keys}}
     </g>
-  </svg>
+  </g>
+</svg>
 </script>
 </div>
 <div id='summary_print'></div><!-- just a div to make the summary print work -->

--- a/kb.js
+++ b/kb.js
@@ -195,8 +195,11 @@
       console.log(name);
       return name || "keyboard-layout";
     }
+		$scope.getSvg = function() {
+			return $renderKey.fullSVG($scope.keys(), $scope.keyboard.meta, $sanitize);
+		};
 		$scope.downloadSvg = function() {
-			var data = $renderKey.fullSVG($scope.keys(), $scope.keyboard.meta);
+			var data = $scope.getSvg();
 			var blob = new Blob([data], {type:"image/svg+xml"});
 			saveAs(blob, $scope.getFilename()+".svg");
 		};

--- a/render.js
+++ b/render.js
@@ -138,7 +138,7 @@ var $renderKey = (typeof(exports) !== 'undefined') ? exports : {};
 	$renderKey.init = function() {
 		keycap_html = doT.template($('#keycap_html').html(), {__proto__: doT.templateSettings, varname:"key, sizes, parms, $sanitize, lightenColor"});
 		keycap_svg = doT.template($('#keycap_svg').html(), {__proto__: doT.templateSettings, varname:"key, sizes, parms, $sanitize, lightenColor", strip:false});
-		keyboard_svg = doT.template($('#keyboard_svg').html(), {__proto__: doT.templateSettings, varname:"parms", strip:false});
+		keyboard_svg = doT.template($('#keyboard_svg').html(), {__proto__: doT.templateSettings, varname:"parms, $sanitize", strip:false});
 	};
 
 	// Given a key, generate the HTML needed to render it
@@ -180,13 +180,13 @@ var $renderKey = (typeof(exports) !== 'undefined') ? exports : {};
 		return keycap_svg(key, sizes, parms, $sanitize, lightenColor);
 	};
 
-	$renderKey.fullSVG = function(keys, metadata) {
+	$renderKey.fullSVG = function(keys, metadata, $sanitize) {
 		// Render all the keys
 		var units = "px";
 	  var bbox = { x: 99999999, y:99999999, x2:-99999999, y2:-99999999 };
 	  var keysSVG = "";
 	  keys.forEach(function(key,index) {	  	
-	  	keysSVG += $renderKey.svg(key, index, bbox, unitSizes[units][getProfile(key)]);
+		keysSVG += $renderKey.svg(key, index, bbox, unitSizes[units][getProfile(key)], $sanitize);
 	  });
 
 	  // Wrap with SVG boilerplate


### PR DESCRIPTION
Previously, SVG rendered blank keycaps only. Now, "Download SVG" renders text labels rather adequately.

Although icons (`<i class="..."></i>`) are still absent, this significantly improves the output.

Example:
![dctucker ergodox](https://github.com/user-attachments/assets/cba39404-0e3d-4078-98aa-e8a955a3ce9a)
